### PR TITLE
Add TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ npm install pncp-sdk
 import { Contratacoes, Contratos, Atas, PCA, Instrumentos } from 'pncp-sdk';
 ```
 
+### Uso com TypeScript
+
+```ts
+import type { ContratacoesParams } from 'pncp-sdk';
+
+const dados = await Contratacoes.consultarPublicacao<SeuTipo>(
+  {} as ContratacoesParams
+);
+```
+
 ---
 
 ## ✅ Exemplos de uso
@@ -59,6 +69,11 @@ console.log(atas);
 ## ⚙️ Configuração
 
 Caso necessário, edite o arquivo `config.js` para customizar o `BASE_URL` da API (por padrão, apontando para o ambiente oficial do PNCP).
+
+```js
+// config.js
+export const BASE_URL = 'https://seu-endereco/api';
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
   "exports": {
     "require": "./pncpClient.cjs",
     "import": "./pncpClient.js"
-  }
+  },
+  "types": "./pncpClient.d.ts"
 }

--- a/pncpClient.d.ts
+++ b/pncpClient.d.ts
@@ -1,0 +1,54 @@
+export type DateInput = string | Date;
+
+export interface PaginationParams {
+  pagina: number;
+  tamanhoPagina?: number;
+}
+
+export interface DataRangeParams {
+  dataInicial: DateInput;
+  dataFinal: DateInput;
+}
+
+export interface ContratacoesParams extends DataRangeParams, PaginationParams {
+  codigoModalidadeContratacao: number;
+  codigoModoDisputa?: number;
+  uf?: string;
+  codigoMunicipioIbge?: string;
+  cnpj?: string;
+  codigoUnidadeAdministrativa?: string;
+  idUsuario?: number;
+}
+
+export interface ContratosParams extends DataRangeParams, PaginationParams {}
+export interface AtasParams extends DataRangeParams, PaginationParams {}
+export interface PCAParams extends DataRangeParams, PaginationParams {}
+export interface InstrumentosParams extends PaginationParams {}
+
+export namespace Contratacoes {
+  function consultarPublicacao<T = any>(params: ContratacoesParams): Promise<T>;
+  function consultarProposta<T = any>(params: ContratacoesParams): Promise<T>;
+  function consultarAtualizacao<T = any>(params: ContratacoesParams): Promise<T>;
+}
+
+export namespace Contratos {
+  function consultarPublicacao<T = any>(params: ContratosParams): Promise<T>;
+  function consultarAtualizacao<T = any>(params: ContratosParams): Promise<T>;
+}
+
+export namespace Atas {
+  function consultarPeriodo<T = any>(params: AtasParams): Promise<T>;
+  function consultarAtualizacao<T = any>(params: AtasParams): Promise<T>;
+}
+
+export namespace PCA {
+  function consultar<T = any>(params: PCAParams): Promise<T>;
+  function consultarUsuario<T = any>(params: PCAParams): Promise<T>;
+  function consultarAtualizacao<T = any>(params: PCAParams): Promise<T>;
+}
+
+export namespace Instrumentos {
+  function consultarInclusao<T = any>(params: InstrumentosParams): Promise<T>;
+}
+
+export const BASE_URL: string;


### PR DESCRIPTION
## Summary
- provide TypeScript declarations for sdk functions
- expose the declarations via `types` field
- document TypeScript usage and config customization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c5de54ef88332ac0c388e0d4b2909